### PR TITLE
Loosen redis dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-gem 'redis', '~> 3.1.0'
+gem 'redis', '~> 3.1'
 gem 'activesupport'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,7 +54,7 @@ GEM
     rake (10.3.2)
     rdoc (3.12.2)
       json (~> 1.4)
-    redis (3.1.0)
+    redis (3.2.1)
     simplecov (0.9.0)
       docile (~> 1.1.0)
       multi_json
@@ -75,7 +75,7 @@ DEPENDENCIES
   jeweler (~> 2.0.1)
   minitest
   rdoc (~> 3.12)
-  redis (~> 3.1.0)
+  redis (~> 3.1)
   simplecov
   timecop (~> 0.7.1)
   yard (~> 0.7)

--- a/retained.gemspec
+++ b/retained.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<redis>, ["~> 3.1.0"])
+      s.add_runtime_dependency(%q<redis>, ["~> 3.1"])
       s.add_runtime_dependency(%q<activesupport>, [">= 0"])
       s.add_development_dependency(%q<minitest>, [">= 0"])
       s.add_development_dependency(%q<yard>, ["~> 0.7"])
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<simplecov>, [">= 0"])
       s.add_development_dependency(%q<timecop>, ["~> 0.7.1"])
     else
-      s.add_dependency(%q<redis>, ["~> 3.1.0"])
+      s.add_dependency(%q<redis>, ["~> 3.1"])
       s.add_dependency(%q<activesupport>, [">= 0"])
       s.add_dependency(%q<minitest>, [">= 0"])
       s.add_dependency(%q<yard>, ["~> 0.7"])
@@ -68,7 +68,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<timecop>, ["~> 0.7.1"])
     end
   else
-    s.add_dependency(%q<redis>, ["~> 3.1.0"])
+    s.add_dependency(%q<redis>, ["~> 3.1"])
     s.add_dependency(%q<activesupport>, [">= 0"])
     s.add_dependency(%q<minitest>, [">= 0"])
     s.add_dependency(%q<yard>, ["~> 0.7"])


### PR DESCRIPTION
The new redis gem (>= 3.2.0) has mainline support for sentinel which I'd like to be able to use, but retained is locked at 3.1.0, it'd be awesome if this could get lifted.
